### PR TITLE
Adding js usage to the README using `Runner.run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,34 @@ This passes the source of all passed through the transform module specified
 with `-t` or `--transform` (defaults to `transform.js` in the current
 directory). The next section explains the structure of the transform module.
 
+## Usage (JS)
+
+```js
+const {run: jscodeshift} = require('jscodeshift/src/Runner')
+
+const transformPath = 'transform.js'
+const paths = ['foo.js', 'bar']
+const options = {
+  dry: true,
+  print: true,
+  verbose: 1,
+  // ...
+}
+
+const res = await jscodeshift(transformPath, paths, options)
+console.log(res)
+/*
+{
+  stats: {},
+  timeElapsed: '0.001',
+  error: 0,
+  ok: 0,
+  nochange: 0,
+  skip: 0
+}
+*/
+```
+
 ## Transform module
 
 The transform is simply a module that exports a function of the form:


### PR DESCRIPTION
Implements @abernier's documentation addition for using the js api https://github.com/facebook/jscodeshift/pull/456

Bug originally reported in
https://github.com/facebook/jscodeshift/issues/398