### PR TITLE
Switching to elonvolo/recast fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evcodeshift",
-  "version": "0.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "evcodeshift",
-      "version": "0.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.17.2",
@@ -25,7 +25,7 @@
         "micromatch": "^4.0.4",
         "neo-async": "^2.6.2",
         "node-dir": "^0.1.17",
-        "recast": "^0.21.0",
+        "recast": "github:ElonVolo/recast",
         "temp": "^0.9.4",
         "write-file-atomic": "^4.0.1"
       },
@@ -8033,8 +8033,8 @@
     },
     "node_modules/recast": {
       "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.21.0.tgz",
-      "integrity": "sha512-N5AMXswCdYlwSULChM5Xsy0ERoP2Zphjp0X94mxRCgJNEggVIfFwOHnWsUanaS2OQrQ9Wi7Hzyp+v3rzFVhRXQ==",
+      "resolved": "git+ssh://git@github.com/ElonVolo/recast.git#c76017b847decf439acfacfadf1d15955979a18f",
+      "license": "MIT",
       "dependencies": {
         "ast-types": "0.15.2",
         "esprima": "~4.0.0",
@@ -16186,9 +16186,8 @@
       }
     },
     "recast": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.21.0.tgz",
-      "integrity": "sha512-N5AMXswCdYlwSULChM5Xsy0ERoP2Zphjp0X94mxRCgJNEggVIfFwOHnWsUanaS2OQrQ9Wi7Hzyp+v3rzFVhRXQ==",
+      "version": "git+ssh://git@github.com/ElonVolo/recast.git#c76017b847decf439acfacfadf1d15955979a18f",
+      "from": "recast@github:ElonVolo/recast",
       "requires": {
         "ast-types": "0.15.2",
         "esprima": "~4.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "micromatch": "^4.0.4",
     "neo-async": "^2.6.2",
     "node-dir": "^0.1.17",
-    "recast": "^0.21.0",
+    "recast": "github:ElonVolo/recast",
     "temp": "^0.9.4",
     "write-file-atomic": "^4.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3489,10 +3489,9 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-recast@^0.21.0:
+"recast@github:ElonVolo/recast":
   version "0.21.0"
-  resolved "https://registry.npmjs.org/recast/-/recast-0.21.0.tgz"
-  integrity sha512-N5AMXswCdYlwSULChM5Xsy0ERoP2Zphjp0X94mxRCgJNEggVIfFwOHnWsUanaS2OQrQ9Wi7Hzyp+v3rzFVhRXQ==
+  resolved "git+ssh://git@github.com/ElonVolo/recast.git#c76017b847decf439acfacfadf1d15955979a18f"
   dependencies:
     ast-types "0.15.2"
     esprima "~4.0.0"


### PR DESCRIPTION
Switching to recast elonvolo/recast fork. This change is being made because the upstream project wasn't merging bugfixes fast enough and evcodeshift needs to provide the latest updated functionality possible.