### PR TITLE
Adding ability to save actual test output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## evcodeshift [2.2.1] 2022-03-09
 
+### Added
+
+- A `saveoutput` parameter to the defineTest() function that allows the results of the transformations to be be saved to a file so they can be more easily be inspected by a text editor or other tools.
+
 ### Changed
 
 - Switched from `recast` to `@putout/recast` as the @coderaiser's fork seems to be more recently maintained than the `recast` upstream, and also because `@output/recast` fixed a bug introdcued by `recast@0.21.0` where transformations that specificied single quotes where still outputting with double quotes.

--- a/sample/__tests__/reverse-identifiers-test.js
+++ b/sample/__tests__/reverse-identifiers-test.js
@@ -24,6 +24,18 @@ defineTest(__dirname, 'reverse-identifiers');
 
 defineTest(__dirname, 'reverse-identifiers', null, 'typescript/reverse-identifiers', { parser: 'ts' });
 
+// defineTest(__dirname, 'reverse-identifiers', null, 'typescript/reverse-identifiers', { parser: 'ts', saveoutput: true });
+//
+// The commented out test above would run the same as the uncommented one above it, but passing in value true for saveoutput will create
+// the following directory structure in the project root
+//
+//   unit_test_output
+//     /reverse-identifiers
+//        /reverse-identifiers.input.js             # The original code given to the unit test
+//        /reverse-identifiers.output.js            # The output that the unit test is expecting to see if all goes well
+//        /reverse-identifiers.transformed.js       # The actual result of running the transformation (may different from output if unit test is failing)
+//
+
 describe('reverse-identifiers', () => {
   defineInlineTest(transform, {}, `
 var firstWord = 'Hello ';


### PR DESCRIPTION
Adds the `saveoutput` option flag to the defineTest() function, to allow the transformed output from running the unit tests to be saved for future inspections.